### PR TITLE
Improve usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,37 +27,38 @@ OpenList sites = new OpenList();
 
 Random rand = new Random(100);
 // create a root polygon which limits the voronoi diagram.
-//  here it is just a rectangle.
-		 
+// here it is just a rectangle.
+
 PolygonSimple rootPolygon = new PolygonSimple();
 int width = 1000;
 int height = 1000;
 rootPolygon.add(0, 0);
 rootPolygon.add(width, 0);
 rootPolygon.add(width, height);
-rootPolygon.add(0, height);		
-		
+rootPolygon.add(0, height);
+
 // create 100 points (sites) and set random positions in the rectangle defined above.
-	for (int i = 0; i < 100; i++) {
-		Site site = new Site(rand.nextInt(width), rand.nextInt(width));
-		// we could also set a different weighting to some sites
-		// site.setWeight(30)
-		sites.add(site);
-		}
-		
+for (int i = 0; i < 100; i++) {
+	Site site = new Site(rand.nextInt(width), rand.nextInt(width));
+	// we could also set a different weighting to some sites
+	// site.setWeight(30)
+	sites.add(site);
+}
+
 // set the list of points (sites), necessary for the power diagram
 diagram.setSites(sites);
 // set the clipping polygon, which limits the power voronoi diagram
 diagram.setClipPoly(rootPolygon);
-		
+
 // do the computation
-diagram.computeDiagram();	
+diagram.computeDiagram();
+
 // for each site we can no get the resulting polygon of its cell. 
 // note that the cell can also be empty, in this case there is no polygon for the corresponding site.
-		for (int i=0;i<sites.size;i++){
-			Site site=sites.array[i];
-			PolygonSimple polygon=site.getPolygon();
-		}
+for (int i=0;i<sites.size;i++){
+	Site site=sites.array[i];
+	PolygonSimple polygon=site.getPolygon();
+}
 ```
 
 License

--- a/src/kn/uni/voronoitreemap/diagram/PowerDiagram.java
+++ b/src/kn/uni/voronoitreemap/diagram/PowerDiagram.java
@@ -315,13 +315,13 @@ public class PowerDiagram {
 		
 		PowerDiagram diagram = new PowerDiagram();
 
-		//normal list based on an array
+		// normal list based on an array
 		OpenList sites = new OpenList();
 
 		Random rand = new Random(100);
-			//  create a root polygon which limits the voronoi diagram.
-		//  here it is just a rectangle.
-		 
+		// create a root polygon which limits the voronoi diagram.
+		// here it is just a rectangle.
+
 		PolygonSimple rootPolygon = new PolygonSimple();
 		int width = 1000;
 		int height = 1000;
@@ -329,7 +329,6 @@ public class PowerDiagram {
 		rootPolygon.add(width, 0);
 		rootPolygon.add(width, height);
 		rootPolygon.add(0, height);
-		
 		
 		// create 100 points (sites) and set random positions in the rectangle defined above.
 		for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
* The foramtting of the example in the usage section of the README file
  was not optimal
* The corresponding code in PowerDiagram.java has been improved, too
  (consistent white space usage in comments)

You can see the improved rendering of README.md [here](https://github.com/sebkur/power-voronoi-diagram/blob/improve-usage-example/README.md)